### PR TITLE
Enhance Lightspeed Chatbot functionality and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ A reference implementation of a chatbot interface built with React, TypeScript, 
 
 ## 🚀 Quick Start
 
+**Prerequisites**: Ensure the [lightspeed-stack](https://github.com/lightspeed-core/lightspeed-stack) is running to provide the backend API services.
+
+If you need help getting `lightspeed-stack` running follow this [guide](https://github.com/lightspeed-core/lightspeed-stack/blob/main/docs/getting_started.md).
+
 ```bash
 git clone https://github.com/your-org/lightspeed-reference-ui
 cd lightspeed-reference-ui
@@ -166,6 +170,7 @@ Body: {
 Response: Server-Sent Events stream with events:
 - start: { conversation_id: string }
 - token: { id: number, role: string, token: string }
+- tool_call: { id: number, role: string, token: string | Record<string, any> }
 - end: { referenced_documents: any[], truncated: any, input_tokens: number, output_tokens: number }
 ```
 
@@ -245,6 +250,6 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 ## 🆘 Support
 
 If you encounter any issues or have questions:
-- Check the [Issues](https://github.com/your-org/lightspeed-reference-ui/issues) page
+- Check the [Issues](https://github.com/lightspeed-core/lightspeed-reference-ui/issues) page
 - Review the component documentation in `src/app/LightspeedChatbot/README.md`
 - Refer to the [PatternFly documentation](https://www.patternfly.org/get-started/develop) for UI components

--- a/src/app/LightspeedChatbot/services/api.ts
+++ b/src/app/LightspeedChatbot/services/api.ts
@@ -6,6 +6,7 @@ import {
   StreamEvent,
   StreamStartData,
   StreamTokenData,
+  StreamToolCallData,
   StreamEndData,
   ConversationResponse,
 } from '../types';
@@ -79,6 +80,7 @@ export const sendStreamingQuery = async (
   onToken: (token: string, tokenData?: StreamTokenData) => void,
   onStart: (conversationId: string) => void,
   onEnd: (endData: StreamEndData) => void,
+  onToolCall: (toolCallData: StreamToolCallData) => void,
 ): Promise<void> => {
   try {
     const response = await fetch(`${API_BASE_URL}/v1/streaming_query`, {
@@ -116,6 +118,10 @@ export const sendStreamingQuery = async (
               case 'start':
                 const startData = eventData.data as StreamStartData;
                 onStart(startData.conversation_id);
+                break;
+              case 'tool_call':
+                const toolCallData = eventData.data as StreamToolCallData;
+                onToolCall(toolCallData);
                 break;
               case 'token':
                 const tokenData = eventData.data as StreamTokenData;

--- a/src/app/LightspeedChatbot/types.ts
+++ b/src/app/LightspeedChatbot/types.ts
@@ -14,6 +14,7 @@ export interface QueryRequest {
   conversation_id?: string;
   provider?: string;
   model?: string;
+  no_tools?: boolean;
   system_prompt?: string;
   attachments?: Array<{
     attachment_type: string;
@@ -42,7 +43,7 @@ export interface ConversationResponse {
 
 // Streaming types
 export interface StreamEvent {
-  event: 'start' | 'token' | 'end';
+  event: 'start' | 'token' | 'tool_call' | 'end';
   data: any;
 }
 
@@ -54,6 +55,12 @@ export interface StreamTokenData {
   id: number;
   role: string;
   token: string;
+}
+
+export interface StreamToolCallData {
+  id: number;
+  role: string;
+  token: string | Record<string, any>;
 }
 
 export interface StreamEndData {


### PR DESCRIPTION
- Added prerequisites and setup instructions for running the backend API services in the README.
- Updated the `QueryRequest` interface to include a `no_tools` property.
- Modified the `StreamEvent` interface to support a new `tool_call` event type.
- Introduced `StreamToolCallData` interface for handling tool call data in streaming responses.
- Updated the `useChatbot` hook to manage tool call events and integrate them into the chatbot's state management.
- Adjusted API service to handle tool call events in the streaming query response.